### PR TITLE
fix: enable run_automation on incident artifacts (GPB-650054)

### DIFF
--- a/ds_on_poll_connector.py
+++ b/ds_on_poll_connector.py
@@ -308,7 +308,7 @@ class DSOnPollConnector:
         artifact["type"] = " "
         artifact["start_time"] = now.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
         artifact["source_data_identifier"] = intelligence_incident.id
-        artifact["run_automation"] = False
+        artifact["run_automation"] = True
         artifact["cef"] = dict()
         artifact["cef"]["externalId"] = intelligence_incident.id
         artifact["cef"]["deviceAddress"] = f"https://portal-digitalshadows.com/client/intelligence/incident/{intelligence_incident.id}"
@@ -412,7 +412,7 @@ class DSOnPollConnector:
         artifact["type"] = " "
         artifact["start_time"] = now.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
         artifact["source_data_identifier"] = incident.id
-        artifact["run_automation"] = False
+        artifact["run_automation"] = True
         artifact["cef"] = dict()
         artifact["cef"]["externalId"] = incident.id
         artifact["cef"]["deviceAddress"] = "https://www.portal-digitalshadows.com/client/incidents/{}".format(incident.payload["id"])

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* Enabled run_automation on ingested incident and intelligence incident artifacts so SOAR playbooks trigger as expected (GPB-650054)


### PR DESCRIPTION
### Bug Fixes

- Fixed `run_automation` being hardcoded to `False` on every ingested artifact in `ds_on_poll_connector.py`, which prevented SOAR playbooks from triggering after incident ingestion. Both `_prepare_intel_incident_artifact` (line 311) and `_prepare_incident_artifact` (line 415) now set `run_automation = True` so playbook automation fires on ingestion as expected.

  **Background:** `run_automation` has been hardcoded to `False` on every ingested artifact since the initial public commit in November 2020. Both incident ingestion paths create a single artifact per container, so setting it to `False` meant the SOAR automation engine never received a signal to evaluate playbooks for these containers. Peer Splunk-maintained connectors all set `run_automation = True` on the single/last artifact of a batch:
  - [`mssentinel/mssentinel_connector.py:506`](https://github.com/splunk-soar-connectors/mssentinel/blob/main/mssentinel_connector.py#L506) — `artifacts[-1]["run_automation"] = True`
  - [`qradar/qradar_connector.py:437`](https://github.com/splunk-soar-connectors/qradar/blob/main/qradar_connector.py#L437) — `"run_automation": True` with an inline comment explaining SOAR 5.0.0+ deduplicates the trigger across a batch
  - [`proofpoint/proofpoint_connector.py:261`](https://github.com/splunk-soar-connectors/proofpoint/blob/main/proofpoint_connector.py#L261) — `artifacts[-1]["run_automation"] = True`

  **Customer impact:** A customer has been running this connector with a local patch flipping these exact two lines since at least 2020 to keep their playbooks functional. They lost the patch during the recent upgrade to 2.2.2 (which they took to pick up the blank-alerts fix in #18), at which point automation stopped firing. This change ships their patch upstream so no customer needs to maintain a local fork. Internal ticket: GPB-650054.

### Manual Documentation

<details><summary>
Have you made any changes that should be documented in manual_readme_content.md?
</summary><br />

The following changes require documentation in `manual_readme_content.md`:

- New, updated, or removed [REST handlers](https://docs.splunk.com/Documentation/SOAR/current/DevelopApps/RESTHandlers)
- New, updated, or removed authentication methods, especially complex methods like OAuth
- Compatibility considerations with respect to deployment types (e.g. actions that cannot be run on cloud or an automation broker)
</details>

- [x] I have verified that manual documentation has been updated where appropriate
